### PR TITLE
feat(siteinfo): support banner slides

### DIFF
--- a/src/app/(administrador)/admin/mensaje-cliente/page.tsx
+++ b/src/app/(administrador)/admin/mensaje-cliente/page.tsx
@@ -2,11 +2,26 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { ArrowUpTrayIcon, PaintBrushIcon } from '@heroicons/react/24/solid';
+import { EyeIcon } from '@heroicons/react/24/outline';
 import {
   fetchSendCustomerMessage,
   fetchGetCustomerMessage,
+  type BannerSlideData,
 } from '@/services/actions/system.actions';
-import { EyeIcon } from '@heroicons/react/24/outline';
+
+type AdminBannerSlide = BannerSlideData & {
+  id: string;
+  desktopPreviewUrl?: string;
+  mobilePreviewUrl?: string;
+};
+
+const createEmptySlide = (): AdminBannerSlide => ({
+  id: `slide-${Date.now()}`,
+  desktop_image: '',
+  mobile_image: '',
+  alt: 'Banner principal',
+  enabled: true,
+});
 
 export default function MensajesCliente() {
   const [modalActivo, setModalActivo] = useState(true);
@@ -16,24 +31,16 @@ export default function MensajesCliente() {
 
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingData, setIsLoadingData] = useState(true);
-  const [message, setMessage] = useState<{
-    type: 'success' | 'error';
-    text: string;
-  } | null>(null);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
-  // refs de inputs file
   const modalInputRef = useRef<HTMLInputElement>(null);
-  const desktopBannerRef = useRef<HTMLInputElement>(null);
-  const responsiveBannerRef = useRef<HTMLInputElement>(null);
-
-  // archivos seleccionados
   const [modalFile, setModalFile] = useState<File | null>(null);
-  const [desktopFile, setDesktopFile] = useState<File | null>(null);
-  const [responsiveFile, setResponsiveFile] = useState<File | null>(null);
+  const [modalFileName, setModalFileName] = useState('');
+  const [modalImageUrl, setModalImageUrl] = useState<string | null>(null);
+  const [bannerSlides, setBannerSlides] = useState<AdminBannerSlide[]>([]);
 
-  // Función para validar tamaño de archivo (máximo 15MB)
   const validateFileSize = (file: File): boolean => {
-    const maxSize = 15 * 1024 * 1024; // 15MB en bytes
+    const maxSize = 15 * 1024 * 1024;
     if (file.size > maxSize) {
       setMessage({
         type: 'error',
@@ -41,167 +48,164 @@ export default function MensajesCliente() {
       });
       return false;
     }
+
     return true;
   };
 
-  // nombres de archivos
-  const [modalFileName, setModalFileName] = useState('');
-  const [desktopFileName, setDesktopFileName] = useState('');
-  const [responsiveFileName, setResponsiveFileName] = useState('');
-
-  // Estados para URLs de previsualización de imágenes
-  const [desktopImageUrl, setDesktopImageUrl] = useState<string | null>(null);
-  const [responsiveImageUrl, setResponsiveImageUrl] = useState<string | null>(null);
-  const [modalImageUrl, setModalImageUrl] = useState<string | null>(null);
-
-  // Función para crear URL de previsualización
-  const createPreviewUrl = (file: File): string => {
-    return URL.createObjectURL(file);
+  const cleanupPreviewUrl = (url?: string) => {
+    if (url?.startsWith('blob:')) {
+      URL.revokeObjectURL(url);
+    }
   };
 
-  // Función para limpiar URL de previsualización
-  const cleanupPreviewUrl = (url: string) => {
-    URL.revokeObjectURL(url);
-  };
-
-  // Función para cargar datos existentes
   const loadExistingData = async () => {
     setIsLoadingData(true);
+
     try {
       const result = await fetchGetCustomerMessage();
 
       if (result.ok && result.data) {
         const data = result.data;
 
-        // Cargar datos del header
         setHeaderColor(data.header.color);
         setHeaderMensaje(data.header.content);
-
-        // Cargar estados de banner y modal
         setBannerActivo(data.banner.enabled);
         setModalActivo(data.modal.enabled);
+        setBannerSlides(
+          data.banner.slides.map((slide) => ({
+            ...slide,
+            id: slide.id || `slide-${slide.order}`,
+            desktopPreviewUrl: slide.desktop_image,
+            mobilePreviewUrl: slide.mobile_image,
+          }))
+        );
 
-        // Cargar nombres de archivos existentes (si los hay)
-        if (data.banner.desktop_image) {
-          setDesktopFileName('Imagen desktop cargada');
-          setDesktopFile(null);
-          setDesktopImageUrl(data.banner.desktop_image);
-        }
-        if (data.banner.mobile_image) {
-          setResponsiveFileName('Imagen móvil cargada');
-          setResponsiveFile(null);
-          setResponsiveImageUrl(data.banner.mobile_image);
-        }
         if (data.modal.image) {
           setModalFileName('Imagen modal cargada');
           setModalFile(null);
           setModalImageUrl(data.modal.image);
         }
-              } else {
-          setMessage({
+      } else {
+        setMessage({
           type: 'error',
           text: result.error || 'Error al cargar los datos existentes',
         });
       }
-    } catch (error) {
-      setMessage({
-        type: 'error',
-        text: 'Error inesperado al cargar los datos',
-      });
+    } catch {
+      setMessage({ type: 'error', text: 'Error inesperado al cargar los datos' });
     } finally {
       setIsLoadingData(false);
     }
   };
 
-  // Cargar datos al montar el componente
   useEffect(() => {
     loadExistingData();
   }, []);
 
-  // Cleanup de URLs de previsualización al desmontar el componente
   useEffect(() => {
     return () => {
-      if (desktopImageUrl && desktopImageUrl.startsWith('blob:')) {
-        cleanupPreviewUrl(desktopImageUrl);
-      }
-      if (responsiveImageUrl && responsiveImageUrl.startsWith('blob:')) {
-        cleanupPreviewUrl(responsiveImageUrl);
-      }
-      if (modalImageUrl && modalImageUrl.startsWith('blob:')) {
-        cleanupPreviewUrl(modalImageUrl);
-      }
+      cleanupPreviewUrl(modalImageUrl || undefined);
+      bannerSlides.forEach((slide) => {
+        cleanupPreviewUrl(slide.desktopPreviewUrl);
+        cleanupPreviewUrl(slide.mobilePreviewUrl);
+      });
     };
-  }, [desktopImageUrl, responsiveImageUrl, modalImageUrl]);
+  }, []);
 
+  const updateSlide = (id: string, patch: Partial<AdminBannerSlide>) => {
+    setBannerSlides((slides) => slides.map((slide) => (slide.id === id ? { ...slide, ...patch } : slide)));
+  };
 
+  const handleSlideFile = (slide: AdminBannerSlide, file: File, kind: 'desktop' | 'mobile') => {
+    if (!validateFileSize(file)) {
+      return;
+    }
 
-  // Función para manejar el guardado
+    const previewUrl = URL.createObjectURL(file);
+
+    if (kind === 'desktop') {
+      cleanupPreviewUrl(slide.desktopPreviewUrl);
+      updateSlide(slide.id, { desktop_file: file, desktopPreviewUrl: previewUrl });
+    } else {
+      cleanupPreviewUrl(slide.mobilePreviewUrl);
+      updateSlide(slide.id, { mobile_file: file, mobilePreviewUrl: previewUrl });
+    }
+
+    setMessage(null);
+  };
+
+  const removeSlide = (id: string) => {
+    const slide = bannerSlides.find((item) => item.id === id);
+    cleanupPreviewUrl(slide?.desktopPreviewUrl);
+    cleanupPreviewUrl(slide?.mobilePreviewUrl);
+    setBannerSlides((slides) => slides.filter((item) => item.id !== id));
+  };
+
+  const moveSlide = (index: number, direction: -1 | 1) => {
+    const nextIndex = index + direction;
+    if (nextIndex < 0 || nextIndex >= bannerSlides.length) {
+      return;
+    }
+
+    setBannerSlides((slides) => {
+      const nextSlides = [...slides];
+      [nextSlides[index], nextSlides[nextIndex]] = [nextSlides[nextIndex], nextSlides[index]];
+      return nextSlides;
+    });
+  };
+
   const handleSave = async () => {
     setIsLoading(true);
     setMessage(null);
 
     try {
-      const messageData = {
+      const result = await fetchSendCustomerMessage({
         header_color: headerColor,
         header_content: headerMensaje,
-        message_enabled: true, // Always enabled since we removed the toggle
-        banner_desktop_image: desktopFile || undefined,
-        banner_mobile_image: responsiveFile || undefined,
+        message_enabled: true,
         banner_enabled: bannerActivo,
+        banner_slides: bannerSlides.map((slide, index) => ({
+          id: slide.id,
+          desktop_image: slide.desktop_image || '',
+          mobile_image: slide.mobile_image || '',
+          desktop_file: slide.desktop_file,
+          mobile_file: slide.mobile_file,
+          alt: slide.alt || 'Banner principal',
+          order: index + 1,
+          enabled: slide.enabled !== false,
+        })),
         modal_image: modalFile || undefined,
         modal_enabled: modalActivo,
-      };
-
-      console.log('Datos enviados al backend para actualización:', messageData);
-
-      const result = await fetchSendCustomerMessage(messageData);
-
-      if (result.ok) {
-        setMessage({
-          type: 'success',
-          text: 'Mensajes guardados exitosamente',
-        });
-      } else {
-        setMessage({
-          type: 'error',
-          text: result.error || 'Error al guardar los mensajes',
-        });
-      }
-    } catch (error) {
-      setMessage({
-        type: 'error',
-        text: 'Error inesperado al guardar los mensajes',
       });
+
+      setMessage({
+        type: result.ok ? 'success' : 'error',
+        text: result.ok ? 'Mensajes guardados exitosamente' : result.error || 'Error al guardar los mensajes',
+      });
+    } catch {
+      setMessage({ type: 'error', text: 'Error inesperado al guardar los mensajes' });
     } finally {
       setIsLoading(false);
     }
   };
 
-  // Mostrar loading mientras se cargan los datos
   if (isLoadingData) {
     return (
       <div className="max-w-5xl mx-auto p-6">
         <div className="flex justify-center items-center h-64">
           <div className="text-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-lime-500 mx-auto mb-4"></div>
-            <p className="text-slate-600">
-              Cargando configuración de mensajes...
-            </p>
+            <p className="text-slate-600">Cargando configuración de mensajes...</p>
           </div>
         </div>
       </div>
     );
   }
 
-
-
   return (
     <div className="max-w-5xl mx-auto p-6 space-y-10">
-      {/* Encabezado */}
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
-        <h1 className="text-2xl font-bold text-slate-800">
-          Mensajes para el cliente
-        </h1>
+        <h1 className="text-2xl font-bold text-slate-800">Mensajes para el cliente</h1>
         <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto">
           <button
             onClick={() => (window.location.href = '/')}
@@ -220,24 +224,15 @@ export default function MensajesCliente() {
         </div>
       </div>
 
-      {/* Mensaje de estado */}
       {message && (
-        <div
-          className={`p-4 rounded text-sm ${
-            message.type === 'success'
-              ? 'bg-green-100 text-green-800 border border-green-200'
-              : 'bg-red-100 text-red-800 border border-red-200'
-          }`}
-        >
+        <div className={`p-4 rounded text-sm ${message.type === 'success' ? 'bg-green-100 text-green-800 border border-green-200' : 'bg-red-100 text-red-800 border border-red-200'}`}>
           {message.text}
         </div>
       )}
 
-      {/* Modal */}
       <section className="space-y-2">
         <h2 className="text-lg font-semibold text-slate-700">Modal</h2>
         <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
-          {/* Botón subir imagen modal */}
           <div className="w-full sm:w-1/2">
             <input
               type="file"
@@ -245,20 +240,12 @@ export default function MensajesCliente() {
               ref={modalInputRef}
               onChange={(e) => {
                 const file = e.target.files?.[0];
-                if (file) {
-                  if (validateFileSize(file)) {
-                    // Limpiar URL anterior si existe
-                    if (modalImageUrl && modalImageUrl.startsWith('blob:')) {
-                      cleanupPreviewUrl(modalImageUrl);
-                    }
-                    setModalFile(file);
-                    setModalFileName(file.name);
-                    setModalImageUrl(createPreviewUrl(file));
-                    setMessage(null); // Limpiar mensajes anteriores
-                  } else {
-                    // Limpiar el input si la validación falla
-                    e.target.value = '';
-                  }
+                if (file && validateFileSize(file)) {
+                  cleanupPreviewUrl(modalImageUrl || undefined);
+                  setModalFile(file);
+                  setModalFileName(file.name);
+                  setModalImageUrl(URL.createObjectURL(file));
+                  setMessage(null);
                 }
               }}
               className="hidden"
@@ -271,190 +258,118 @@ export default function MensajesCliente() {
               <ArrowUpTrayIcon className="w-5 h-5" />
               Subir imagen
             </button>
-            {modalFileName && (
-              <p className="text-xs text-gray-500 mt-1 truncate">
-                {modalFileName}
-              </p>
-            )}
-            {modalImageUrl && (
-              <img src={modalImageUrl} alt="Imagen modal actual" className="mt-2 max-h-24 rounded border" />
-            )}
+            {modalFileName && <p className="text-xs text-gray-500 mt-1 truncate">{modalFileName}</p>}
+            {modalImageUrl && <img src={modalImageUrl} alt="Imagen modal actual" className="mt-2 max-h-24 rounded border" />}
           </div>
 
-          {/* Activar/desactivar */}
           <div className="flex items-center gap-3">
             <label className="flex items-center gap-1 text-sm">
-              <input
-                type="radio"
-                name="modal"
-                checked={modalActivo}
-                onChange={() => setModalActivo(true)}
-              />
+              <input type="radio" name="modal" checked={modalActivo} onChange={() => setModalActivo(true)} />
               Activar
             </label>
             <label className="flex items-center gap-1 text-sm">
-              <input
-                type="radio"
-                name="modal"
-                checked={!modalActivo}
-                onChange={() => setModalActivo(false)}
-              />
+              <input type="radio" name="modal" checked={!modalActivo} onChange={() => setModalActivo(false)} />
               Desactivar
             </label>
           </div>
         </div>
-        <div>
-          <p className="text-sm text-lime-600 font-medium">
-            Recomendaciones de carga
-          </p>
-          <p className="text-sm text-gray-600">
-            Resolución recomendada: <strong>620x400 px</strong>
-            <br />
-            Peso máximo por imagen: <strong>15 MB</strong>
-            <br />
-            JPEG: Comprimido al 70–80% para mantener calidad con un tamaño
-            pequeño.
-          </p>
-        </div>
+        <p className="text-sm text-gray-600">
+          Resolución recomendada: <strong>620x400 px</strong>. Peso máximo por imagen: <strong>15 MB</strong>.
+        </p>
       </section>
 
-      {/* Banner principal */}
       <section className="bg-slate-50 p-4 rounded space-y-4">
-        <h2 className="text-lg font-semibold text-slate-700">
-          Banner principal
-        </h2>
-        <div className="flex flex-col md:flex-row items-start md:items-center gap-4 w-full">
-          {/* Botón desktop */}
-          <div className="w-full sm:w-auto">
-            <input
-              type="file"
-              accept="image/*"
-              ref={desktopBannerRef}
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) {
-                  if (validateFileSize(file)) {
-                    // Limpiar URL anterior si existe
-                    if (desktopImageUrl && desktopImageUrl.startsWith('blob:')) {
-                      cleanupPreviewUrl(desktopImageUrl);
-                    }
-                    setDesktopFile(file);
-                    setDesktopFileName(file.name);
-                    setDesktopImageUrl(createPreviewUrl(file));
-                    setMessage(null); // Limpiar mensajes anteriores
-                  } else {
-                    // Limpiar el input si la validación falla
-                    e.target.value = '';
-                  }
-                }
-              }}
-              className="hidden"
-            />
-            <button
-              type="button"
-              onClick={() => desktopBannerRef.current?.click()}
-              className="flex justify-center sm:justify-start items-center gap-2 border rounded px-4 py-2 text-sm w-full sm:w-auto"
-            >
-              <ArrowUpTrayIcon className="w-5 h-5" />
-              Subir imagen desktop
-            </button>
-            {desktopFileName && (
-              <p className="text-xs text-gray-500 mt-1 truncate">
-                {desktopFileName}
-              </p>
-            )}
-            {desktopImageUrl && (
-              <img src={desktopImageUrl} alt="Imagen desktop actual" className="mt-2 max-h-24 rounded border" />
-            )}
-          </div>
-
-          {/* Botón responsivo */}
-          <div className="w-full sm:w-auto">
-            <input
-              type="file"
-              accept="image/*"
-              ref={responsiveBannerRef}
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) {
-                  if (validateFileSize(file)) {
-                    // Limpiar URL anterior si existe
-                    if (responsiveImageUrl && responsiveImageUrl.startsWith('blob:')) {
-                      cleanupPreviewUrl(responsiveImageUrl);
-                    }
-                    setResponsiveFile(file);
-                    setResponsiveFileName(file.name);
-                    setResponsiveImageUrl(createPreviewUrl(file));
-                    setMessage(null); // Limpiar mensajes anteriores
-                  } else {
-                    // Limpiar el input si la validación falla
-                    e.target.value = '';
-                  }
-                }
-              }}
-              className="hidden"
-            />
-            <button
-              type="button"
-              onClick={() => responsiveBannerRef.current?.click()}
-              className="flex justify-center items-center gap-2 w-full sm:w-auto border rounded px-4 py-2 text-sm"
-            >
-              <ArrowUpTrayIcon className="w-5 h-5" />
-              Subir imagen responsivo
-            </button>
-            {responsiveFileName && (
-              <p className="text-xs text-gray-500 mt-1 truncate">
-                {responsiveFileName}
-              </p>
-            )}
-            {responsiveImageUrl && (
-              <img src={responsiveImageUrl} alt="Imagen móvil actual" className="mt-2 max-h-24 rounded border" />
-            )}
-          </div>
-
-          {/* Activar/desactivar */}
-          <div className="flex items-center gap-3">
-            <label className="flex items-center gap-1 text-sm">
-              <input
-                type="radio"
-                name="banner"
-                checked={bannerActivo}
-                onChange={() => setBannerActivo(true)}
-              />
-              Activar
-            </label>
-            <label className="flex items-center gap-1 text-sm">
-              <input
-                type="radio"
-                name="banner"
-                checked={!bannerActivo}
-                onChange={() => setBannerActivo(false)}
-              />
-              Desactivar
-            </label>
-          </div>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <h2 className="text-lg font-semibold text-slate-700">Banner principal</h2>
+          <button
+            type="button"
+            onClick={() => setBannerSlides((slides) => [...slides, createEmptySlide()])}
+            className="w-full sm:w-auto border border-lime-500 text-lime-700 rounded px-4 py-2 text-sm hover:bg-lime-50"
+          >
+            Agregar slide
+          </button>
         </div>
-        <div>
-          <p className="text-sm text-lime-600 font-medium">
-            Recomendaciones de carga
-          </p>
-          <p className="text-sm text-gray-600">
-            Resolución recomendada: <strong>1500 x 400 px</strong> para desktop
-            y <strong>750 x 400 px</strong> para responsivo
-            <br />
-            Peso máximo por imagen: <strong>15 MB</strong>
-            <br />
-            JPEG: Comprimido al 70–80% para mantener calidad con un tamaño
-            pequeño.
-          </p>
+
+        <div className="flex items-center gap-3">
+          <label className="flex items-center gap-1 text-sm">
+            <input type="radio" name="banner" checked={bannerActivo} onChange={() => setBannerActivo(true)} />
+            Activar
+          </label>
+          <label className="flex items-center gap-1 text-sm">
+            <input type="radio" name="banner" checked={!bannerActivo} onChange={() => setBannerActivo(false)} />
+            Desactivar
+          </label>
         </div>
+
+        {bannerSlides.length === 0 && (
+          <div className="rounded border border-dashed border-slate-300 p-6 text-sm text-slate-500 text-center">
+            No hay slides configurados. Agregá uno para mostrar el banner del catálogo.
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {bannerSlides.map((slide, index) => (
+            <article key={slide.id} className="rounded border bg-white p-4 space-y-4">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                <h3 className="font-medium text-slate-700">Slide {index + 1}</h3>
+                <div className="flex flex-wrap gap-2">
+                  <button type="button" onClick={() => moveSlide(index, -1)} disabled={index === 0} className="border rounded px-3 py-1 text-xs disabled:opacity-40">Subir</button>
+                  <button type="button" onClick={() => moveSlide(index, 1)} disabled={index === bannerSlides.length - 1} className="border rounded px-3 py-1 text-xs disabled:opacity-40">Bajar</button>
+                  <button type="button" onClick={() => removeSlide(slide.id)} className="border border-red-200 text-red-600 rounded px-3 py-1 text-xs">Eliminar</button>
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <label className="space-y-2 text-sm">
+                  <span className="font-medium text-slate-600">Imagen desktop</span>
+                  <input type="file" accept="image/*" onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) handleSlideFile(slide, file, 'desktop');
+                  }} />
+                  {slide.desktopPreviewUrl && <img src={slide.desktopPreviewUrl} alt="Preview desktop" className="max-h-28 rounded border" />}
+                </label>
+
+                <label className="space-y-2 text-sm">
+                  <span className="font-medium text-slate-600">Imagen responsiva</span>
+                  <input type="file" accept="image/*" onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) handleSlideFile(slide, file, 'mobile');
+                  }} />
+                  {slide.mobilePreviewUrl && <img src={slide.mobilePreviewUrl} alt="Preview móvil" className="max-h-28 rounded border" />}
+                </label>
+              </div>
+
+              <div className="grid md:grid-cols-[1fr_auto] gap-4 items-end">
+                <label className="space-y-1 text-sm">
+                  <span className="font-medium text-slate-600">Texto alternativo</span>
+                  <input
+                    type="text"
+                    value={slide.alt || ''}
+                    onChange={(event) => updateSlide(slide.id, { alt: event.target.value })}
+                    className="w-full rounded border px-3 py-2 text-sm"
+                    placeholder="Descripción del banner"
+                  />
+                </label>
+                <label className="flex items-center gap-2 text-sm min-h-10">
+                  <input
+                    type="checkbox"
+                    checked={slide.enabled !== false}
+                    onChange={(event) => updateSlide(slide.id, { enabled: event.target.checked })}
+                  />
+                  Slide activo
+                </label>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <p className="text-sm text-gray-600">
+          Resolución recomendada: <strong>1500 x 400 px</strong> para desktop y <strong>750 x 400 px</strong> para responsivo. Peso máximo por imagen: <strong>15 MB</strong>.
+        </p>
       </section>
 
-      {/* Mensaje en el header */}
       <section className="space-y-4">
-        <h2 className="text-lg font-semibold text-slate-700">
-          Mensaje en el header
-        </h2>
+        <h2 className="text-lg font-semibold text-slate-700">Mensaje en el header</h2>
         <div className="grid md:grid-cols-2 gap-4">
           <textarea
             placeholder="Ingresar el mensaje de su preferencia"
@@ -465,15 +380,9 @@ export default function MensajesCliente() {
           <div className="space-y-2">
             <label className="block text-sm">Seleccionar color de fondo</label>
             <div className="flex items-center gap-2">
-              <input
-                type="color"
-                value={headerColor}
-                onChange={(e) => setHeaderColor(e.target.value)}
-                className="w-10 h-10 rounded border cursor-pointer"
-              />
+              <input type="color" value={headerColor} onChange={(e) => setHeaderColor(e.target.value)} className="w-10 h-10 rounded border cursor-pointer" />
               <PaintBrushIcon className="w-5 h-5 text-slate-600" />
             </div>
-
           </div>
         </div>
       </section>

--- a/src/app/(private)/page.tsx
+++ b/src/app/(private)/page.tsx
@@ -108,26 +108,11 @@ export default function PrivatePage() {
     showModalIfValid();
   }, [customerMessage, openModal, userRole]);
 
-  // CÓDIGO ANTERIOR COMENTADO PARA REFERENCIA:
-  // const getCarouselImages = () => {
-  //   if (customerMessage?.banner?.desktop_image && customerMessage?.banner?.mobile_image) {
-  //     // Si hay imágenes del banner configuradas, usarlas
-  //     return [customerMessage.banner.desktop_image, customerMessage.banner.mobile_image];
-  //   }
-  //   // Si no hay imágenes configuradas, usar las imágenes por defecto
-  //   return defaultImages;
-  // };
-
-  // NUEVO CÓDIGO: Determinar qué datos usar para el banner
   const getBannerData = () => {
-    if (
-      customerMessage?.banner?.desktop_image &&
-      customerMessage?.banner?.mobile_image
-    ) {
-      // Si hay datos del banner configurados, usar el objeto completo
+    if (customerMessage?.banner?.slides?.length) {
       return customerMessage.banner;
     }
-    // Si no hay banner configurado, retornar undefined para usar fallback
+
     return undefined;
   };
 
@@ -180,10 +165,6 @@ export default function PrivatePage() {
           <CarouselSkeleton />
         ) : (
           customerMessage?.banner?.enabled && (
-            /* CÓDIGO ANTERIOR COMENTADO:
-            <Caroussel images={getCarouselImages()} />
-            */
-            // NUEVO CÓDIGO: Pasa el objeto banner completo y fallback
             <Caroussel banner={getBannerData()} images={defaultImages} />
           )
         )}

--- a/src/app/components/global/Caroussel.tsx
+++ b/src/app/components/global/Caroussel.tsx
@@ -1,143 +1,117 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-interface BannerData {
+interface BannerSlide {
+  id?: string;
   desktop_image: string;
   mobile_image: string;
+  alt?: string;
+  order?: number;
+  enabled?: boolean;
+}
+
+interface BannerData {
   enabled: boolean;
+  slides?: BannerSlide[];
+  desktop_image?: string;
+  mobile_image?: string;
 }
 
 interface CarouselProps {
-  // Objeto banner del backend
   banner?: BannerData;
-  // Props individuales (alternativa)
   desktopImage?: string;
   mobileImage?: string;
-  // Mantener compatibilidad con la prop anterior (deprecated)
   images?: string[];
-  modalData?: {
-    image: string;
-    enabled: boolean;
-  };
 }
 
-export default function Carousel({ banner, desktopImage, mobileImage, images, modalData }: CarouselProps) {
-  const [isMobile, setIsMobile] = useState(false);
-  const [currentImage, setCurrentImage] = useState<string>('');
+const AUTOPLAY_MS = 5000;
 
-  // Detectar si estamos en dispositivo móvil
+export default function Carousel({ banner, desktopImage, mobileImage, images }: CarouselProps) {
+  const [isMobile, setIsMobile] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
   useEffect(() => {
-    const checkIsMobile = () => {
-      const width = window.innerWidth;
-      const newIsMobile = width < 768; // Tailwind md breakpoint
-      console.log('📱 Detección de dispositivo:', {
-        windowWidth: width,
-        isMobile: newIsMobile,
-        breakpoint: 768,
-        deviceType: newIsMobile ? 'MÓVIL' : 'DESKTOP'
-      });
-      setIsMobile(newIsMobile);
-    };
-    
-    // Verificar al montar el componente
+    const checkIsMobile = () => setIsMobile(window.innerWidth < 768);
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleMotionChange = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+
     checkIsMobile();
-    
-    // Escuchar cambios de tamaño
+    setPrefersReducedMotion(motionQuery.matches);
+
     window.addEventListener('resize', checkIsMobile);
-    
-    return () => window.removeEventListener('resize', checkIsMobile);
+    motionQuery.addEventListener('change', handleMotionChange);
+
+    return () => {
+      window.removeEventListener('resize', checkIsMobile);
+      motionQuery.removeEventListener('change', handleMotionChange);
+    };
   }, []);
 
-  // Determinar qué imagen usar basándose en el dispositivo (reactivo)
+  const slides = useMemo(() => {
+    const bannerSlides = banner?.slides?.length
+      ? banner.slides
+      : banner?.desktop_image || banner?.mobile_image
+        ? [{
+            id: 'legacy-banner',
+            desktop_image: banner.desktop_image || '',
+            mobile_image: banner.mobile_image || '',
+            alt: 'Banner principal',
+            order: 1,
+            enabled: true,
+          }]
+        : [];
+
+    const enabledSlides = bannerSlides
+      .filter((slide) => slide.enabled !== false)
+      .sort((a, b) => (a.order || 0) - (b.order || 0));
+
+    if (enabledSlides.length > 0) {
+      return enabledSlides;
+    }
+
+    if (desktopImage || mobileImage) {
+      return [{ desktop_image: desktopImage || '', mobile_image: mobileImage || '', alt: 'Banner principal' }];
+    }
+
+    return (images || []).map((image, index) => ({
+      id: `fallback-${index}`,
+      desktop_image: image,
+      mobile_image: image,
+      alt: `Banner ${index + 1}`,
+      order: index + 1,
+      enabled: true,
+    }));
+  }, [banner, desktopImage, mobileImage, images]);
+
+  const isBannerEnabled = banner?.enabled !== false;
+  const hasMultipleSlides = slides.length > 1;
+
   useEffect(() => {
-    console.log('🖼️ Selección de imagen (useEffect):', {
-      isMobile,
-      'banner?.desktop_image': banner?.desktop_image,
-      'banner?.mobile_image': banner?.mobile_image,
-      hasBannerImages: !!(banner?.desktop_image && banner?.mobile_image),
-      desktopImage,
-      mobileImage,
-      hasIndividualProps: !!(desktopImage && mobileImage),
-      fallbackImage: images?.[0]
-    });
+    setCurrentIndex(0);
+  }, [slides.length]);
 
-    let selectedImage = '';
-
-    // Prioridad 1: Usar el objeto banner del backend
-    if (banner?.desktop_image && banner?.mobile_image) {
-      selectedImage = isMobile ? banner.mobile_image : banner.desktop_image;
-      console.log('✅ Usando banner del backend:', {
-        isMobile,
-        selectedImage,
-        source: isMobile ? 'mobile_image' : 'desktop_image'
-      });
-    }
-    // Prioridad 2: Usar props individuales
-    else if (desktopImage && mobileImage) {
-      selectedImage = isMobile ? mobileImage : desktopImage;
-      console.log('✅ Usando props individuales:', {
-        isMobile,
-        selectedImage,
-        source: isMobile ? 'mobileImage prop' : 'desktopImage prop'
-      });
-    }
-    // Fallback: Primera imagen del array original para compatibilidad
-    else {
-      selectedImage = images?.[0] || '';
-      console.log('✅ Usando fallback:', {
-        selectedImage,
-        source: 'images[0]'
-      });
-    }
-
-    setCurrentImage(selectedImage);
-  }, [isMobile, banner?.desktop_image, banner?.mobile_image, desktopImage, mobileImage, images]);
-
-  // Verificar si el banner está habilitado
-  const isBannerEnabled = banner?.enabled !== false; // Por defecto true si no se especifica
-
-  // Console log para debug (detallado)
   useEffect(() => {
-    console.log('🔍 Banner Debug - Datos actuales:', {
-      // Detección de dispositivo
-      isMobile,
-      windowWidth: typeof window !== 'undefined' ? window.innerWidth : 'undefined',
-      breakpoint: 768,
-      
-      // Datos del banner
-      banner,
-      'banner.desktop_image': banner?.desktop_image,
-      'banner.mobile_image': banner?.mobile_image,
-      'banner.enabled': banner?.enabled,
-      
-      // Props individuales
-      desktopImage,
-      mobileImage,
-      
-      // Imagen seleccionada
-      currentImage,
-      imageSource: banner?.desktop_image && banner?.mobile_image 
-        ? 'banner object' 
-        : desktopImage && mobileImage 
-          ? 'individual props'
-          : 'fallback images array',
-      
-      // Estado
-      isBannerEnabled,
-      modalData
-    });
-  }, [currentImage, banner, desktopImage, mobileImage, isMobile, isBannerEnabled, modalData]);
+    if (!hasMultipleSlides || isPaused || prefersReducedMotion) {
+      return;
+    }
 
-  // No mostrar nada si el banner está deshabilitado
+    const timer = window.setInterval(() => {
+      setCurrentIndex((index) => (index + 1) % slides.length);
+    }, AUTOPLAY_MS);
+
+    return () => window.clearInterval(timer);
+  }, [hasMultipleSlides, isPaused, prefersReducedMotion, slides.length]);
+
   if (!isBannerEnabled) {
     return null;
   }
 
-  // Mostrar placeholder si no hay imagen
-  if (!currentImage) {
+  if (!slides.length) {
     return (
-      <div className="w-full max-w-7xl h-[144px] sm:h-[344px] mx-auto px-4">
+      <div className="w-full max-w-7xl h-[200px] sm:h-[344px] mx-auto px-4">
         <div className="w-full h-full flex items-center justify-center rounded-lg bg-gray-200">
           <p className="text-gray-500">No hay imagen para mostrar</p>
         </div>
@@ -145,40 +119,73 @@ export default function Carousel({ banner, desktopImage, mobileImage, images, mo
     );
   }
 
+  const goToPrevious = () => setCurrentIndex((index) => (index - 1 + slides.length) % slides.length);
+  const goToNext = () => setCurrentIndex((index) => (index + 1) % slides.length);
+
   return (
-    <div className="w-full max-w-7xl sm:h-[344px] h-[200px] mx-auto relative px-4">
-      {/* Container de imagen con bordes redondeados */}
-      <div className="w-full h-full overflow-hidden rounded-lg">
-        {/* 
-        // CÓDIGO ANTERIOR DEL CARRUSEL COMENTADO PARA REFERENCIA FUTURA:
-        // Este era el código que renderizaba un carrusel con múltiples imágenes
-        // <div
-        //   className="flex transition-transform duration-500 ease-in-out w-full h-full"
-        //   style={{ transform: `translateX(-${currentIndex * 100}%)` }}
-        // >
-        //   {images.map((image, index) => (
-        //     <div key={index} className="w-full h-full flex-shrink-0">
-        //       <img
-        //         src={image}
-        //         alt={`Slide ${index + 1}`}
-        //         className="w-full h-full object-cover"
-        //       />
-        //     </div>
-        //   ))}
-        // </div>
-        // 
-        // + Botones de navegación
-        // + Indicadores
-        // + Autoplay
-        */}
-        
-        {/* NUEVO CÓDIGO: Renderiza imagen del backend específica según el dispositivo */}
-        <img
-          src={currentImage}
-          alt={`Banner - ${isMobile ? 'Móvil' : 'Desktop'}`}
-          className="w-full h-full object-contain"
-        />
+    <section
+      className="w-full max-w-7xl h-[200px] sm:h-[344px] mx-auto relative px-4"
+      aria-label="Banner principal"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+      onFocus={() => setIsPaused(true)}
+      onBlur={() => setIsPaused(false)}
+    >
+      <div className="w-full h-full overflow-hidden rounded-lg bg-white">
+        <div
+          className="flex h-full transition-transform duration-500 ease-in-out"
+          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+        >
+          {slides.map((slide, index) => {
+            const image = isMobile ? slide.mobile_image || slide.desktop_image : slide.desktop_image || slide.mobile_image;
+
+            return (
+              <div key={slide.id || index} className="w-full h-full flex-shrink-0">
+                <img
+                  src={image}
+                  alt={slide.alt || `Banner ${index + 1}`}
+                  className="w-full h-full object-contain"
+                />
+              </div>
+            );
+          })}
+        </div>
       </div>
-    </div>
+
+      {hasMultipleSlides && (
+        <>
+          <button
+            type="button"
+            aria-label="Banner anterior"
+            onClick={goToPrevious}
+            className="absolute left-6 top-1/2 -translate-y-1/2 min-h-11 min-w-11 rounded-full bg-white/80 text-slate-700 shadow hover:bg-white focus:outline-none focus:ring-2 focus:ring-lime-500"
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            aria-label="Banner siguiente"
+            onClick={goToNext}
+            className="absolute right-6 top-1/2 -translate-y-1/2 min-h-11 min-w-11 rounded-full bg-white/80 text-slate-700 shadow hover:bg-white focus:outline-none focus:ring-2 focus:ring-lime-500"
+          >
+            ›
+          </button>
+
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-2">
+            {slides.map((slide, index) => (
+              <button
+                key={slide.id || index}
+                type="button"
+                aria-label={`Ver banner ${index + 1}`}
+                onClick={() => setCurrentIndex(index)}
+                className={`h-3 w-3 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-lime-500 ${
+                  currentIndex === index ? 'bg-lime-500' : 'bg-white/80'
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </section>
   );
 }

--- a/src/services/actions/system.actions.ts
+++ b/src/services/actions/system.actions.ts
@@ -3,32 +3,90 @@
 import { BACKEND_URL, IS_QA_MODE } from '@/utils/getEnv';
 import { cookiesManagement } from '@/stores/base/utils/cookiesManagement';
 
+export interface BannerSlideData {
+  id?: string;
+  desktop_image?: string;
+  mobile_image?: string;
+  desktop_file?: File;
+  mobile_file?: File;
+  alt?: string;
+  order?: number;
+  enabled?: boolean;
+}
+
 interface CustomerMessageData {
   header_color: string;
   header_content: string;
   message_enabled: boolean;
   banner_desktop_image?: File;
   banner_mobile_image?: File;
+  banner_slides?: BannerSlideData[];
   banner_enabled: boolean;
   modal_image?: File;
   modal_enabled: boolean;
 }
 
-interface CustomerMessageResponse {
+export interface CustomerMessageResponse {
   header: {
     color: string;
     content: string;
   };
   banner: {
-    desktop_image: string;
-    mobile_image: string;
     enabled: boolean;
+    slides: Array<{
+      id: string;
+      desktop_image: string;
+      mobile_image: string;
+      alt: string;
+      order: number;
+      enabled: boolean;
+    }>;
   };
   modal: {
     image: string;
     enabled: boolean;
   };
 }
+
+const normalizeCustomerMessage = (data: any): CustomerMessageResponse => {
+  const banner = data?.banner || {};
+  const legacySlides = banner.desktop_image || banner.mobile_image
+    ? [{
+        id: 'legacy-banner',
+        desktop_image: banner.desktop_image || '',
+        mobile_image: banner.mobile_image || '',
+        alt: 'Banner principal',
+        order: 1,
+        enabled: true,
+      }]
+    : [];
+
+  const slides = Array.isArray(banner.slides) ? banner.slides : legacySlides;
+
+  return {
+    header: {
+      color: data?.header?.color || '#ffffff',
+      content: data?.header?.content || '',
+    },
+    banner: {
+      enabled: Boolean(banner.enabled),
+      slides: slides
+        .map((slide: any, index: number) => ({
+          id: String(slide.id || `banner-${index + 1}`),
+          desktop_image: String(slide.desktop_image || ''),
+          mobile_image: String(slide.mobile_image || ''),
+          alt: String(slide.alt || 'Banner principal'),
+          order: Number(slide.order || index + 1),
+          enabled: slide.enabled !== false,
+        }))
+        .sort((a: { order: number }, b: { order: number }) => a.order - b.order),
+    },
+    modal: {
+      image: data?.modal?.image || '',
+      enabled: Boolean(data?.modal?.enabled),
+    },
+  };
+};
 
 interface ActionResult<T> {
   ok: boolean;
@@ -49,9 +107,8 @@ export const fetchGetCustomerMessage = async (): Promise<ActionResult<CustomerMe
           content: 'Bienvenido a Socomarca'
         },
         banner: {
-          desktop_image: '',
-          mobile_image: '',
-          enabled: true
+          enabled: true,
+          slides: []
         },
         modal: {
           image: '',
@@ -109,7 +166,7 @@ export const fetchGetCustomerMessage = async (): Promise<ActionResult<CustomerMe
     }
 
     // Extraer la estructura correcta que espera el slice
-    const responseData = data.respuesta || data;
+    const responseData = normalizeCustomerMessage(data.respuesta || data);
 
     return {
       ok: true,
@@ -181,6 +238,26 @@ export const fetchSendCustomerMessage = async (
     if (messageData.banner_mobile_image) {
       formData.append('banner_mobile_image', messageData.banner_mobile_image);
     }
+
+    messageData.banner_slides?.forEach((slide, index) => {
+      if (slide.id) {
+        formData.append(`banner_slides[${index}][id]`, slide.id);
+      }
+
+      formData.append(`banner_slides[${index}][alt]`, slide.alt || 'Banner principal');
+      formData.append(`banner_slides[${index}][order]`, String(slide.order || index + 1));
+      formData.append(`banner_slides[${index}][enabled]`, slide.enabled === false ? '0' : '1');
+      formData.append(`banner_slides[${index}][existing_desktop_image]`, slide.desktop_image || '');
+      formData.append(`banner_slides[${index}][existing_mobile_image]`, slide.mobile_image || '');
+
+      if (slide.desktop_file) {
+        formData.append(`banner_slides[${index}][desktop_image]`, slide.desktop_file);
+      }
+
+      if (slide.mobile_file) {
+        formData.append(`banner_slides[${index}][mobile_image]`, slide.mobile_file);
+      }
+    });
     
     if (messageData.modal_image) {
       formData.append('modal_image', messageData.modal_image);

--- a/src/stores/base/slices/customerMessageSlice.ts
+++ b/src/stores/base/slices/customerMessageSlice.ts
@@ -9,9 +9,15 @@ export interface CustomerMessageSlice {
       content: string;
     };
     banner: {
-      desktop_image: string;
-      mobile_image: string;
       enabled: boolean;
+      slides: Array<{
+        id: string;
+        desktop_image: string;
+        mobile_image: string;
+        alt: string;
+        order: number;
+        enabled: boolean;
+      }>;
     };
     modal: {
       image: string;

--- a/src/stores/base/types.ts
+++ b/src/stores/base/types.ts
@@ -403,9 +403,15 @@ export interface StoreState extends LoadingStates, AuthState {
       content: string;
     };
     banner: {
-      desktop_image: string;
-      mobile_image: string;
       enabled: boolean;
+      slides: Array<{
+        id: string;
+        desktop_image: string;
+        mobile_image: string;
+        alt: string;
+        order: number;
+        enabled: boolean;
+      }>;
     };
     modal: {
       image: string;


### PR DESCRIPTION
## Summary
- Updates customer message data handling to support banner slides from the backend.
- Replaces the catalog banner with a multi-slide carousel using responsive desktop/mobile images.
- Reworks the admin customer message page to add, reorder, enable, and upload multiple banner slides.

## Changes
| File | Change |
|------|--------|
| `src/services/actions/system.actions.ts` | Adds banner slide types, response normalization, and FormData fields for slide image uploads. |
| `src/stores/base/types.ts` | Updates customer message banner state shape to `slides[]`. |
| `src/stores/base/slices/customerMessageSlice.ts` | Updates customer message slice banner type. |
| `src/app/components/global/Caroussel.tsx` | Implements real carousel behavior with autoplay, controls, indicators, responsive images, pause, and reduced-motion support. |
| `src/app/(private)/page.tsx` | Passes the new banner slide contract to the carousel. |
| `src/app/(administrador)/admin/mensaje-cliente/page.tsx` | Adds admin slide management with uploads, previews, alt text, ordering, and active state. |

## Test Plan
- [x] `npx tsc --noEmit`
- [ ] Manual QA against backend `/api/customer-message`

## Notes
- Does not include existing Android/iOS working tree changes.
- Requires backend banner slide contract already merged in `socomarca-backend` PR #437.