### PR TITLE
fix: evitar solicitudes duplicadas en confirmación de pago

### DIFF
--- a/src/app/(private)/confirmacion-pago/page.tsx
+++ b/src/app/(private)/confirmacion-pago/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import LoadingSpinner from '@/app/components/global/LoadingSpinner';
 import { getWebpayPaymentDetail } from '@/services/actions/payment.actions';
@@ -11,6 +11,10 @@ import {
   ClipboardIcon,
 } from '@heroicons/react/24/outline';
 
+// Caché por token_ws para confirmar el pago una sola vez aunque la página se
+// remonte o Strict Mode duplique el efecto (evita órdenes duplicadas).
+const webpayRequestCache = new Map<string, Promise<any>>();
+
 type Estado =
   | { status: 'loading' }
   | { status: 'success'; data: any }
@@ -20,25 +24,44 @@ export default function ConfirmacionPagoPage() {
   const [estado, setEstado] = useState<Estado>({ status: 'loading' });
   const [copiado, setCopiado] = useState(false);
   const router = useRouter();
+  const yaEjecutado = useRef(false);
 
   useEffect(() => {
+    // Evita el doble-invoke de Strict Mode dentro de un mismo montaje.
+    if (yaEjecutado.current) return;
+    yaEjecutado.current = true;
+
     const token_ws = new URLSearchParams(window.location.search).get('token_ws');
     if (!token_ws) {
       setEstado({ status: 'error', message: 'No se pudo completar la operación de pago.' });
       return;
     }
 
-    (async () => {
-      try {
-        const data = await getWebpayPaymentDetail(token_ws);
-        setEstado({ status: 'success', data });
-      } catch (error: any) {
-        setEstado({
-          status: 'error',
-          message: error?.message || 'No se pudo confirmar el pago.',
-        });
-      }
-    })();
+    let cancelado = false;
+
+    // Reutiliza la petición en curso/previa de este token; no duplica órdenes.
+    let request = webpayRequestCache.get(token_ws);
+    if (!request) {
+      request = getWebpayPaymentDetail(token_ws);
+      webpayRequestCache.set(token_ws, request);
+    }
+
+    request
+      .then((data) => {
+        if (!cancelado) setEstado({ status: 'success', data });
+      })
+      .catch((error: any) => {
+        if (!cancelado) {
+          setEstado({
+            status: 'error',
+            message: error?.message || 'No se pudo confirmar el pago.',
+          });
+        }
+      });
+
+    return () => {
+      cancelado = true;
+    };
   }, []);
 
   const formatCLP = (valor: number) =>

--- a/src/app/(private)/layout.tsx
+++ b/src/app/(private)/layout.tsx
@@ -66,24 +66,26 @@ export default function PrivateLayout({
         <Header carro={cartProducts} />
 
         <main className="flex-grow relative w-full py-3 bg-slate-100 sm:pt-8">
-          {isLoading ? (
-            <div className="flex justify-center items-center h-full min-h-[200px]">
+          {/*
+            Spinner como overlay SIN desmontar los children: `isLoading` es un
+            flag global que oscila al cargar en paralelo y, si condicionara el
+            render, remontaría la página y re-ejecutaría sus efectos.
+          */}
+          {isLoading && (
+            <div className="absolute inset-0 z-20 flex justify-center items-center bg-slate-100/70">
               <LoadingSpinner />
             </div>
-          ) : (
-            <>
-              {isAdminUser && (
-                <div className="w-full max-w-7xl mx-auto px-4 mb-4">
-                  <div className="w-full rounded-lg px-4 py-2 text-center text-white font-medium shadow-sm bg-orange-500">
-                    Modo de solo lectura - No puedes realizar compras
-                  </div>
-                </div>
-              )}
-              <div className={isAdminUser ? 'admin-readonly-mode' : ''}>
-                {children}
-              </div>
-            </>
           )}
+          {isAdminUser && (
+            <div className="w-full max-w-7xl mx-auto px-4 mb-4">
+              <div className="w-full rounded-lg px-4 py-2 text-center text-white font-medium shadow-sm bg-orange-500">
+                Modo de solo lectura - No puedes realizar compras
+              </div>
+            </div>
+          )}
+          <div className={isAdminUser ? 'admin-readonly-mode' : ''}>
+            {children}
+          </div>
         </main>
 
         {/* Footer */}

--- a/src/stores/base/types.ts
+++ b/src/stores/base/types.ts
@@ -99,6 +99,7 @@ export interface AuthSlice extends AuthState {
     rut: string;
     password: string;
     role?: string;
+    normalizeRut?: boolean;
   }) => Promise<{ success: boolean; error?: string; user?: User }>;
   logout: () => Promise<void>;
   initializeFromAuth: () => Promise<void>;


### PR DESCRIPTION
- layout privado: spinner como overlay sin desmontar los children, para que isLoading no remonte la página y re-dispare sus efectos
- confirmación de pago: guard por token_ws para confirmar el pago una sola vez (evita órdenes duplicadas en remontajes/Strict Mode)
- tipa normalizeRut en AuthSlice.login