### PR TITLE
fix(carro): mostrar nombres de producto completos sin truncar

### DIFF
--- a/src/app/components/carro-de-compra/CarroCompraCard.tsx
+++ b/src/app/components/carro-de-compra/CarroCompraCard.tsx
@@ -27,12 +27,9 @@ export default function CarroCompraCard({ product }: CartCardProps) {
     isLoading,
     backgroundImage,
     totalPrice,
-    isBrandTruncated,
-    isNameTruncated,
     decreaseQuantity,
     increaseQuantity,
     deleteAllQuantity,
-    truncateText
   } = useCartItem(product);
 
   return (
@@ -47,9 +44,6 @@ export default function CarroCompraCard({ product }: CartCardProps) {
         <ProductInfo
           brandName={product.brand?.name || 'Sin marca'}
           productName={product.name}
-          isBrandTruncated={isBrandTruncated}
-          isNameTruncated={isNameTruncated}
-          truncateText={truncateText}
         />
       </td>
 

--- a/src/app/components/carro-de-compra/CartComponents.tsx
+++ b/src/app/components/carro-de-compra/CartComponents.tsx
@@ -27,31 +27,13 @@ export const ProductImage = ({ backgroundImage, alt }: ProductImageProps) => (
 interface ProductInfoProps {
   brandName: string;
   productName: string;
-  isBrandTruncated: boolean;
-  isNameTruncated: boolean;
-  truncateText: (text: string) => string;
 }
 
-export const ProductInfo = ({ 
-  brandName, 
-  productName, 
-  isBrandTruncated, 
-  isNameTruncated, 
-  truncateText 
-}: ProductInfoProps) => (
-  <div>
-    <p
-      className="text-xs text-slate-400 cursor-help"
-      title={isBrandTruncated ? brandName : undefined}
-    >
-      {isBrandTruncated ? truncateText(brandName) : brandName}
-    </p>
-    <p
-      data-cy="cart-item-name"
-      className="text-black text-xs cursor-help"
-      title={isNameTruncated ? productName : undefined}
-    >
-      {isNameTruncated ? truncateText(productName) : productName}
+export const ProductInfo = ({ brandName, productName }: ProductInfoProps) => (
+  <div className="min-w-0">
+    <p className="text-xs text-slate-400 break-words">{brandName}</p>
+    <p data-cy="cart-item-name" className="text-black text-xs break-words">
+      {productName}
     </p>
   </div>
 );

--- a/src/hooks/useCartItem.ts
+++ b/src/hooks/useCartItem.ts
@@ -10,12 +10,9 @@ interface UseCartItemReturn {
   isLoading: boolean;
   backgroundImage: string;
   totalPrice: string;
-  isBrandTruncated: boolean;
-  isNameTruncated: boolean;
   decreaseQuantity: () => Promise<void>;
   increaseQuantity: () => Promise<void>;
   deleteAllQuantity: () => Promise<void>;
-  truncateText: (text: string, maxLength?: number) => string;
 }
 
 export const useCartItem = (product: CartItem): UseCartItemReturn => {
@@ -87,41 +84,21 @@ export const useCartItem = (product: CartItem): UseCartItemReturn => {
       setIsLoading(false);
     }
   }, [isLoading, product, removeProductFromCart, handleError]);
-  /** Trunca texto si excede la longitud máxima */
-  const truncateText = useCallback((text: string, maxLength: number = CART_CONFIG.MAX_TEXT_LENGTH) => {
-    if (text.length > maxLength) {
-      return text.substring(0, maxLength) + '...';
-    }
-    return text;
-  }, []);
 
   // Cálculos memorizados
-  const totalPrice = useMemo(() => 
+  const totalPrice = useMemo(() =>
     (product.price * product.quantity).toLocaleString(CART_CONFIG.LOCALE, {
       style: 'currency',
       currency: CART_CONFIG.CURRENCY,
     }), [product.price, product.quantity]
   );
 
-  const isBrandTruncated = useMemo(() => 
-    (product.brand?.name?.length || 0) > CART_CONFIG.MAX_TEXT_LENGTH, 
-    [product.brand?.name]
-  );
-
-  const isNameTruncated = useMemo(() => 
-    product.name.length > CART_CONFIG.MAX_TEXT_LENGTH, 
-    [product.name]
-  );
-
   return {
     isLoading,
     backgroundImage,
     totalPrice,
-    isBrandTruncated,
-    isNameTruncated,
     decreaseQuantity,
     increaseQuantity,
     deleteAllQuantity,
-    truncateText
   };
 };


### PR DESCRIPTION
Elimina la truncación a 20 caracteres en ProductInfo y usa break-words para que la marca y el nombre del producto se muestren completos en el carro de compra.
