### PR TITLE
fix: manejar campos null de ApiUser al transformar usuarios

### DIFF
--- a/src/app/(administrador)/admin/clientes/page.tsx
+++ b/src/app/(administrador)/admin/clientes/page.tsx
@@ -61,11 +61,11 @@ const ClientsPage = () => {
   const transformApiUserToTableData = (apiUser: ApiUser): ClientTableData => {
     return {
       id: apiUser.id,
-      name: apiUser.name,
-      email: apiUser.email,
-      phone: apiUser.phone,
-      rut: apiUser.rut,
-      business_name: apiUser.business_name,
+      name: apiUser.name ?? '',
+      email: apiUser.email ?? '',
+      phone: apiUser.phone ?? '',
+      rut: apiUser.rut ?? '',
+      business_name: apiUser.business_name ?? '',
       is_active: apiUser.is_active ? 'Activo' : 'Inactivo',
       last_login: apiUser.last_login
         ? new Date(apiUser.last_login).toLocaleDateString('es-CL')

--- a/src/interfaces/user.interface.ts
+++ b/src/interfaces/user.interface.ts
@@ -38,11 +38,11 @@ export interface UpdateCredentialsResponse {
 
 export interface ApiUser {
   id: number;
-  name: string;
-  email: string;
-  phone: string;
-  rut: string;
-  business_name: string;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  rut: string | null;
+  business_name: string | null;
   is_active: boolean;
   last_login: string | null;
   roles: string[];
@@ -98,25 +98,28 @@ export function transformApiUserToUser(apiUser: ApiUser): {
   business_name: string;
   phone: string;
 } {
+  // La API puede devolver estos campos en null (ej: cuentas sin correo registrado)
+  const email = apiUser.email ?? '';
+
   // Separar el nombre completo en nombre y apellido
-  const nameParts = apiUser.name.split(' ');
+  const nameParts = (apiUser.name ?? '').split(' ');
   const firstName = nameParts[0] || '';
   const lastName = nameParts.slice(1).join(' ') || '';
 
   // Obtener el primer rol como perfil, o 'Sin rol' si no hay roles
-  const profile = apiUser.roles && apiUser.roles.length > 0 
+  const profile = apiUser.roles && apiUser.roles.length > 0
     ? apiUser.roles[0].charAt(0).toUpperCase() + apiUser.roles[0].slice(1)
     : 'Sin rol';
 
   return {
     id: apiUser.id,
-    username: apiUser.email.split('@')[0], // Usar parte del email como username
+    username: email.split('@')[0], // Usar parte del email como username
     name: firstName,
     lastname: lastName,
-    email: apiUser.email,
+    email: email,
     profile: profile,
-    rut: apiUser.rut,
-    business_name: apiUser.business_name,
-    phone: apiUser.phone,
+    rut: apiUser.rut ?? '',
+    business_name: apiUser.business_name ?? '',
+    phone: apiUser.phone ?? '',
   };
 }


### PR DESCRIPTION
Este cambio corrige el bug que impedía cargar el listado de usuarios en el panel de super-admin: la pantalla quedaba vacía mostrando "Error: Error inesperado al cargar usuarios" con el botón de Reintentar, y reintentar no servía porque el problema no era de red sino de datos. El origen era que transformApiUserToUser asumía que email siempre venía como string y ejecutaba .split('@') directamente sobre él; al existir al menos un usuario con email en null, esa llamada lanzaba un TypeError que rompía el .map() completo sobre la respuesta de la API. Como el error se propagaba hasta el catch genérico de loadUsers, un único registro incompleto bastaba para tumbar toda la tabla en lugar de afectar solo esa fila, y el mensaje mostrado ocultaba la causa real. Con la normalización de los campos nulos, los usuarios sin correo (o sin nombre, teléfono, RUT o razón social) ya no interrumpen la carga y el listado se renderiza completo.

<img width="1970" height="723" alt="image" src="https://github.com/user-attachments/assets/5c295412-6040-4eaf-9a80-828b03618b73" />


Ahora la API puede devolver email, name, phone, rut y business_name en null (ej: cuentas sin correo registrado). transformApiUserToUser asumia que email era siempre string y el .split('@') lanzaba TypeError, rompiendo el .map() completo y dejando el listado de usuarios en error.

- ApiUser: esos campos pasan a string | null, acorde a la respuesta real
- transformApiUserToUser: normaliza con ?? '' antes de operar
- clientes/page.tsx: mismo normalizado para no renderizar null en tabla

