### PR TITLE
feat(productos): mostrar la lista de precios en la tabla de admin

### DIFF
--- a/src/app/(administrador)/admin/productos/page.tsx
+++ b/src/app/(administrador)/admin/productos/page.tsx
@@ -35,6 +35,11 @@ const columns = [
     label: 'Marca',
     render: (_: any, row: Product) => row.brand?.name,
   },
+  {
+    key: 'price_list_id',
+    label: 'Lista de precios',
+    render: (_: any, row: Product) => row.price_list_id || 'Sin lista',
+  },
 ];
 
 export default function ProductsAdmin() {

--- a/src/interfaces/product.interface.ts
+++ b/src/interfaces/product.interface.ts
@@ -4,6 +4,9 @@ export interface Product {
   price: number;
   stock: number;
   sku: string;
+  // Lista de precios a la que corresponde esta fila. Un mismo producto se repite
+  // una vez por cada lista permitida del usuario, y este campo las distingue.
+  price_list_id: string | null;
   image: string;
   category: Category | null;
   subcategory: Subcategory | null;

--- a/src/mock/products.ts
+++ b/src/mock/products.ts
@@ -148,6 +148,9 @@ const getSubcategoriesByCategory = (categoryId: number): Subcategory[] => {
   return SUBCATEGORIES.filter((sub) => subcategoryIds.includes(sub.id));
 };
 
+// Listas de precios simuladas: en QA un producto puede venir de cualquiera de ellas
+const PRICE_LISTS = ['Lista 1', 'Lista 2', 'Lista Mayorista'];
+
 const getUnitByCategory = (categoryId: number): string => {
   switch (categoryId) {
     case 1: // Alimentos Básicos
@@ -217,6 +220,7 @@ export const generateProduct = (id: number): Product => {
     price,
     stock,
     sku,
+    price_list_id: getRandomElement(PRICE_LISTS),
     image: `/assets/global/logo_plant.png`,
     category,
     subcategory,

--- a/src/services/actions/products.actions.ts
+++ b/src/services/actions/products.actions.ts
@@ -34,6 +34,7 @@ const normalizeProduct = (raw: any): Product => ({
   price: typeof raw.price === 'string' ? parseFloat(raw.price) || 0 : (raw.price ?? 0),
   stock: raw.stock ?? 0,
   sku: raw.sku ?? '',
+  price_list_id: raw.price_list_id ?? null,
   image: raw.image ?? '',
   unit: raw.unit ?? '',
   status: raw.status ?? false,


### PR DESCRIPTION
El listado del backend devuelve una fila por combinacion producto-precio, por lo que un mismo producto se repite una vez por cada lista de precios permitida del usuario. Sin una columna que las distinga, las filas se ven duplicadas sin explicacion.

- Product: nuevo campo price_list_id (string | null)
- normalizeProduct: mapea price_list_id desde la respuesta de la API
- productos/page.tsx: nueva columna "Lista de precios"
- mock: los productos de QA traen una lista simulada

Requiere el cambio del backend que expone price_list_id en el listado.